### PR TITLE
fix: incorrect index number since v1.72 firmware

### DIFF
--- a/DM7 Parameters-2.txt
+++ b/DM7 Parameters-2.txt
@@ -70,7 +70,7 @@ OK prminfo 68 "MIXER:Current/Mix/HPF/Slope" 48 1 6 24 12 "" integer any rw 1
 OK prminfo 69 "MIXER:Current/Mix/LPF/On" 48 1 0 1 0 "" integer any rw 1
 OK prminfo 70 "MIXER:Current/Mix/LPF/Freq" 48 1 200 200000 160000 "" integer any rw 10
 OK prminfo 71 "MIXER:Current/Mix/LPF/Slope" 48 1 6 12 12 "" integer any rw 1
-OK prminfo 120 "MIXER:Current/Mix/PEQ/BankSelect" 48 1 0 1 0 "" integer any rw 1
+OK prminfo 72 "MIXER:Current/Mix/PEQ/BankSelect" 48 1 0 1 0 "" integer any rw 1
 OK prminfo 73 "MIXER:Current/Mix/PEQ/On" 48 1 0 1 1 "" integer any rw 1
 OK prminfo 74 "MIXER:Current/Mix/PEQ/Type" 48 1 0 12 "PRECISE" "" integer any rw 1
 OK prminfo 75 "MIXER:Current/Mix/PEQ/Band/Bypass" 48 8 0 1 0 "" integer any rw 1

--- a/DM7 Parameters-2.txt
+++ b/DM7 Parameters-2.txt
@@ -135,7 +135,7 @@ OK prminfo 168 "MIXER:Current/Monitor/DownMix/CToLOn" 1 1 0 1 0 "" integer any r
 OK prminfo 169 "MIXER:Current/Monitor/DownMix/LFEToLOn" 1 1 0 1 0 "" integer any rw 1
 OK prminfo 170 "MIXER:Current/Monitor/DownMix/LsToLOn" 1 1 0 1 0 "" integer any rw 1
 OK prminfo 171 "MIXER:Current/Monitor/DownMix/RsToLOn" 1 1 0 1 0 "" integer any rw 1
-OK prminfo 1120 "MIXER:Current/Monitor/DownMix/LToROn" 1 1 0 1 0 "" integer any rw 1
+OK prminfo 172 "MIXER:Current/Monitor/DownMix/LToROn" 1 1 0 1 0 "" integer any rw 1
 OK prminfo 173 "MIXER:Current/Monitor/DownMix/RToROn" 1 1 0 1 0 "" integer any rw 1
 OK prminfo 174 "MIXER:Current/Monitor/DownMix/CToROn" 1 1 0 1 0 "" integer any rw 1
 OK prminfo 175 "MIXER:Current/Monitor/DownMix/LFEToROn" 1 1 0 1 0 "" integer any rw 1

--- a/DM7 Parameters-2.txt
+++ b/DM7 Parameters-2.txt
@@ -70,7 +70,7 @@ OK prminfo 68 "MIXER:Current/Mix/HPF/Slope" 48 1 6 24 12 "" integer any rw 1
 OK prminfo 69 "MIXER:Current/Mix/LPF/On" 48 1 0 1 0 "" integer any rw 1
 OK prminfo 70 "MIXER:Current/Mix/LPF/Freq" 48 1 200 200000 160000 "" integer any rw 10
 OK prminfo 71 "MIXER:Current/Mix/LPF/Slope" 48 1 6 12 12 "" integer any rw 1
-OK prminfo 72 "MIXER:Current/Mix/PEQ/BankSelect" 48 1 0 1 0 "" integer any rw 1
+OK prminfo 120 "MIXER:Current/Mix/PEQ/BankSelect" 48 1 0 1 0 "" integer any rw 1
 OK prminfo 73 "MIXER:Current/Mix/PEQ/On" 48 1 0 1 1 "" integer any rw 1
 OK prminfo 74 "MIXER:Current/Mix/PEQ/Type" 48 1 0 12 "PRECISE" "" integer any rw 1
 OK prminfo 75 "MIXER:Current/Mix/PEQ/Band/Bypass" 48 8 0 1 0 "" integer any rw 1


### PR DESCRIPTION
Executing `prminfo 172` on a Yamaha DM7 running v1.72 firmware yields `prminfo 172 "MIXER:Current/Monitor/DownMix/LToROn" 1 1 0 1 0 "" integer any rw 1`